### PR TITLE
feat: Add nerdctl_login role

### DIFF
--- a/roles/nerdctl_login/README.md
+++ b/roles/nerdctl_login/README.md
@@ -1,0 +1,27 @@
+# nerdctl_login
+
+Ansible role for logging into container registries using [nerdctl](https://github.com/containerd/nerdctl).
+
+## Requirements
+
+The nerdctl binary must be installed on the target host and available in the PATH before running this role. This can be done by using the [hostinger.core.nerdctl](../nerdctl) role.
+
+## Dependencies
+
+None.
+
+## Role Variables
+
+Refer to [defaults/main.yml](defaults/main.yml) for a list of variables along with documentation.
+
+## Example Playbook
+
+```yaml
+- hosts: all
+  roles:
+    - role: hostinger.core.nerdctl_login
+```
+
+## License
+
+See [LICENSE](../../LICENSE)

--- a/roles/nerdctl_login/defaults/main.yml
+++ b/roles/nerdctl_login/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+nerdctl_login_config_path: /root/.docker/config.json
+nerdctl_login_registry_url: ""
+nerdctl_login_password: ""
+nerdctl_login_username: ""

--- a/roles/nerdctl_login/meta/main.yml
+++ b/roles/nerdctl_login/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: nerdctl_login
+  author: hostinger
+  description: Ansible role for logging into container registries using nerdctl
+  license: license (MIT)
+  min_ansible_version: "2.10"
+  platforms:
+  - name: Fedora
+    versions:
+    - all
+  - name: Debian
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+  galaxy_tags:
+  - nerdctl

--- a/roles/nerdctl_login/molecule/default/converge.yml
+++ b/roles/nerdctl_login/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts:
+  - all
+
+  roles:
+  - nerdctl_login

--- a/roles/nerdctl_login/molecule/default/molecule.yml
+++ b/roles/nerdctl_login/molecule/default/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: default
+    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    cgroupns_mode: host
+    pre_build_image: true
+    privileged: true
+    platform: amd64
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}

--- a/roles/nerdctl_login/tasks/main.yml
+++ b/roles/nerdctl_login/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Get Docker config contents
+  ansible.builtin.slurp:
+    src: "{{ nerdctl_login_config_path }}"
+  register: nerdctl_login_docker_config
+  ignore_errors: true
+  when:
+    - nerdctl_login_registry_url | length > 0
+
+- name: Login to container registry
+  environment:
+    REGISTRY_PASSWORD: "{{ nerdctl_login_password }}"
+  ansible.builtin.shell: nerdctl login -u {{ nerdctl_login_username }} -p "${REGISTRY_PASSWORD}" {{ nerdctl_login_registry_url }}
+  when:
+    - nerdctl_login_username | length > 0
+    - nerdctl_login_password | length > 0
+    - nerdctl_login_registry_url | length > 0
+    - nerdctl_login_docker_config['content'] is not defined or
+      nerdctl_login_docker_config['content'] | b64decode | from_json | json_query('auths."' ~ nerdctl_login_registry_url ~ '".auth') is not defined


### PR DESCRIPTION
Adding `nerdctl_login` role. Not using [docker_login](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_login_module.html) module as this requires Python and other hard dependencies.