### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       roles: ${{ steps.changed-files.outputs.all_changed_files }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     needs: changed-files
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3
       uses: actions/setup-python@v2


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944