### PR TITLE
feat(SeaweedFS): Manage S3 config

### DIFF
--- a/roles/seaweedfs/tasks/main.yml
+++ b/roles/seaweedfs/tasks/main.yml
@@ -55,6 +55,7 @@
     owner: root
     group: root
   notify:
+    - Reload systemd
     - Restart seaweedfs
 
 - name: Template S3 config file

--- a/roles/seaweedfs/templates/seaweedfs.service.j2
+++ b/roles/seaweedfs/templates/seaweedfs.service.j2
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 User={{ seaweedfs_owner }}
-ExecStart=/usr/bin/weed {{ seaweedfs_command }} {% for arg in seaweedfs_args %}{{ arg }} {% endfor +%}
+ExecStart=/usr/bin/weed {{ seaweedfs_command }} {% if seaweedfs_s3_config %}-s3.config={{ seaweedfs_config_dir }}/s3.conf {% endif %} {% for arg in seaweedfs_args %}{{ arg }} {% endfor %}
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This PR adds automatic addition of the S3 config option, as long as the S3 config is defined.
It uses the pre-defined path in:

https://github.com/hostinger/ansible-collection-common/blob/c24ab45548b9b75181bb18d5f9f769af12785a68/roles/seaweedfs/tasks/main.yml#L63

Additionally, there is a small fix to reload the systemd daemon upon any changes to the service file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved systemd reload process during service configuration file updates for better service restart handling.

* **New Features**
  * Added optional S3 configuration support to seaweedfs service startup when S3 settings are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->